### PR TITLE
some small-ish relpath/abspath fixes to make `./goit .` work

### DIFF
--- a/git.go
+++ b/git.go
@@ -162,8 +162,9 @@ func NewRepo(path string) (repo *GitRepo, ok bool) {
 	repo.Name = filepath.Base(path)
 
 	relPath := path[len(BaseGitDir):]
-	if relPath[0] == '/' {
-		relPath = relPath[1:]
+	relPath = strings.TrimLeft(relPath, "/")
+	if len(relPath) == 0 {
+	    relPath = "."
 	}
 	repo.RelativePath = relPath
 

--- a/goit.go
+++ b/goit.go
@@ -258,7 +258,7 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	if path, err := filepath.Abs(flag.Arg(0)); err != nil {
+	if path, err := filepath.Abs(flag.Arg(0)); err == nil {
 		BaseGitDir = path
 	} else {
 		BaseGitDir = flag.Arg(0)


### PR DESCRIPTION
Before:

$ ./goit .
{"Name":"goit","Path":"/home/buck/trees/theirs/goit","RelativePath":"home/buck/trees/theirs/goit","GitwebUrl":"https://localhost?p=home/buck/trees/theirs/goit","Type":1}

After:

$ ./goit .
{"Name":"goit","Path":"/home/buck/trees/theirs/goit","RelativePath":".","GitwebUrl":"https://localhost?p=.","Type":1}

Note that the relative path was unworkably broken before.
